### PR TITLE
Added a mock UI for the Tool Detail page in the frontend.

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -55,7 +55,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1430,7 +1429,6 @@
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1472,7 +1470,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1578,7 +1575,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1813,7 +1809,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2500,7 +2495,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2562,7 +2556,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2572,7 +2565,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2841,7 +2833,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2963,7 +2954,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/pages/ToolDetail.jsx
+++ b/frontend/src/pages/ToolDetail.jsx
@@ -1,10 +1,6 @@
 import { useParams, Link } from "react-router-dom";
+import mockTools from "../mock/tools.mock";
 
-const mockTools = [
-  { id: 1, name: "Power Drill", category: "Tools", condition: "Good", available: true },
-  { id: 2, name: "Ladder", category: "Home", condition: "Fair", available: false },
-  { id: 3, name: "Camping Tent", category: "Outdoors", condition: "Great", available: true },
-];
 
 export default function ToolDetail() {
   const { id } = useParams();
@@ -20,13 +16,52 @@ export default function ToolDetail() {
   }
 
   return (
-    <div style={{ padding: 16 }}>
-      <Link to="/tools">← Back</Link>
-      <h1 style={{ marginTop: 8 }}>{tool.name}</h1>
-      <p>{tool.category} • {tool.condition}</p>
+  <div style={{ padding: 24, maxWidth: 600, margin: "0 auto" }}>
+    <Link to="/tools" style={{ textDecoration: "none", color: "#555" }}>
+      ← Back to Tools
+    </Link>
+
+    <div
+      style={{
+        marginTop: 16,
+        padding: 20,
+        border: "1px solid #ddd",
+        borderRadius: 8,
+      }}
+    >
+      <h1 style={{ marginBottom: 12 }}>{tool.name}</h1>
+
       <p>
-        Status: <strong>{tool.available ? "Available" : "Unavailable"}</strong>
+        <strong>Category:</strong> {tool.category}
       </p>
+
+      <p>
+        <strong>Condition:</strong> {tool.condition}
+      </p>
+
+      <p>
+        <strong>Status:</strong>{" "}
+        <span style={{ color: tool.available ? "green" : "red" }}>
+          {tool.available ? "Available" : "Unavailable"}
+        </span>
+      </p>
+
+      <button
+        disabled={!tool.available}
+        style={{
+          marginTop: 16,
+          padding: "10px 16px",
+          borderRadius: 4,
+          border: "none",
+          backgroundColor: tool.available ? "#2563eb" : "#aaa",
+          color: "#fff",
+          cursor: tool.available ? "pointer" : "not-allowed",
+        }}
+      >
+        Request to Borrow
+      </button>
     </div>
-  );
+  </div>
+);
+
 }


### PR DESCRIPTION
## What changed?
-  Display includes tool name, description, availability status, and borrowing options.
-  Styled using  CSS  for a basic layout.
-  Page displays tool information: name, category, condition, and availability.
-  Includes a **Request to Borrow** button (disabled if the tool is unavailable).

## Why?
-  Provides a **mock UI** to visualize individual tool details before integrating backend data.
-  Helps the team review the layout and user flow for borrowing tools.

## How to test
1. Run the frontend locally (`npm start`).
2. Navigate to the Tool Detail page via a tool URL, e.g., `/tools/1`.
3. Check that all tool information (name, category, condition, status) displays correctly.
4. Verify the **Request to Borrow** button is enabled only when the tool is available.
5. Test the **Back to Tools** link navigates correctly.

## Screenshots (UI changes)
<img width="263" height="275" alt="Screenshot 2026-02-05 164652" src="https://github.com/user-attachments/assets/9938b187-8b34-4381-a4e9-3a5d6c730787" />

