### PR TITLE
fix(backend): add gitignore rule for venv folder without dot

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,4 +1,5 @@
 .venv/
+venv/
 .env
 *.pyc
 __pycache__/


### PR DESCRIPTION
## What changed?
- I added the venv folder (without ".") to gitignore.

## Why?
- When following the QUICKSTART.md steps, the instructions suggest creating a virtual environment named venv. However, the .gitignore file was only configured to ignore .venv (with a dot), causing all local virtual environment files to appear in source control and clutter the workspace

## How to test
1. Navigate to the backend directory.
2. Create a folder named venv (if you don't have one).
3. Run git status and verify that the venv folder is ignored (it should NOT appear in the list of untracked files).

## Screenshots (UI changes)
<img width="209" height="66" alt="image" src="https://github.com/user-attachments/assets/a42a71a4-987d-4db3-b490-ec05e6a008f3" />
