### PR TITLE
Feat/backend "users" API routes

### DIFF
--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -1,5 +1,5 @@
-from flask import Blueprint, jsonify
-from app.crud import get_all_users, get_user
+from flask import Blueprint, jsonify, request
+from app.crud import get_all_users, get_user, create_user
 
 users_bp = Blueprint('users', __name__)
 
@@ -10,6 +10,14 @@ users_bp = Blueprint('users', __name__)
 def get_users_endpoint():
     users = get_all_users()
     return jsonify(users), 200
+
+@users_bp.route('/users', methods=['POST'])
+def create_user_endpoint():
+    data = request.get_json()
+    user = create_user(data)
+    if type(user) == int:
+        return jsonify({'error': 'something went wrong'}), 400
+    return jsonify(user), 201
 
 @users_bp.route('/users/<int:user_id>', methods=['GET'])
 def get_user_endpoint(user_id):

--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -1,4 +1,4 @@
 """CRUD operations package"""
-from app.crud.user import get_all_users, get_user
+from app.crud.user import get_all_users, get_user, create_user
 
-__all__ = ['get_all_users', 'get_user']
+__all__ = ['get_all_users', 'get_user', 'create_user']

--- a/backend/app/crud/user.py
+++ b/backend/app/crud/user.py
@@ -1,6 +1,6 @@
 from src.extensions import db
 from app.models import User
-from app.schemas import UserSchema, UserProfileSchema
+from app.schemas import UserSchema, UserProfileSchema, UserRegistrationSchema
 
 def get_all_users():
     all_users = db.session.query(User).all()
@@ -11,3 +11,11 @@ def get_user(user_id):
     user = db.session.get(User, user_id)
     user_schema = UserProfileSchema()
     return user_schema.dump(user)
+
+def create_user(data):
+    user_schema = UserRegistrationSchema()
+    try:
+        new_user = user_schema.load(data)
+        return new_user
+    except:
+        return False


### PR DESCRIPTION
## What changed?
- Added API routes for getting the registered user's list, getting a user by id, and creating new users

## Why?
- To make operations on `items` table possible, like adding new items to the library, at least one user must exist in the `users` table, to fulfill the requirement for the item owner's id

## How to test
1. using Postman (or a similar tool) send a "POST" request  with a content type of `application/json` and body with fields like in the example below to confirm that creation of new users is working:
```JSON
{
  "username": "test",
  "full_name": "Test User",
  "email": "example@email.com",
  "password": "1234"
}
```
2. send a "GET request to `http://127.0.0.1:5000/api/users` to receive the list of users in the database (take note of the assigned `id` number for the next step), to confirm that endpoint for getting a full user list is working,
3. send a "GET" request to `http://127.0.0.1:5000/api/users/<id>` (with the id of one of the users from the previous step) to confirm that the endpoint for receiving data about a specific user is working.

