### PR TITLE
fix: added missing closing bracket in 'pyproject.toml'

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,3 +14,4 @@ dependencies = [
     "flask-cors>=6.0.2",
     "flask-marshmallow>=1.4.0",
     "marshmallow-sqlalchemy>=1.4.2",
+]


### PR DESCRIPTION
This adds a missing closing bracket at the end of list of dependencies in 'pyproject.toml'

## Why?
- The missing bracket would cause an error preventing the Flask application from running. 
