### PR TITLE
Add navigation from My Requests to Tool Detail with fallback

### DIFF
--- a/frontend/src/pages/MyRequests.jsx
+++ b/frontend/src/pages/MyRequests.jsx
@@ -1,23 +1,68 @@
 import mockData from "../mock/tools.mock";
+import { Link } from "react-router-dom";
 
 export default function MyRequests() {
   return (
     <div className="container">
       <h1>My Requests</h1>
-      <div style={{
-        display: "grid",
-        gap: 12,
-        marginTop: 16,
-        gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))"
-      }}>
-        {mockData.length >= 1 ? (mockData.map((data) => (
-          <div key={data.id} style={{ border: "1px solid #ddd", borderRadius: 8, padding: 12 }}>
-            <h3 style={{ margin: 0 }}>{data.name}</h3>
-            <span style={{ margin: "6px 0" }} className="muted">Status: {data.available === true ? "Approved ✅" : "Pending ⏳"}</span>
-          </div>
-        ))
-        ) : ("No requests found.")}
+
+      <div
+        style={{
+          display: "grid",
+          gap: 20,
+          marginTop: 18,
+          gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
+        }}
+      >
+        {mockData.length >= 1
+          ? mockData.map((data) => (
+              <div
+                key={data.id}
+                style={{
+                  border: "1px solid #ddd",
+                  borderRadius: 8,
+                  padding: 16,
+                  display: "flex",
+                  flexDirection: "column",
+                  justifyContent: "space-between",
+                }}
+              >
+                <h3 style={{ margin: 0 }}>{data.name}</h3>
+
+                <div
+                  style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 8,
+                    marginTop: 12,
+                  }}
+                >
+                  <span className="muted">
+                    Status:{" "}
+                    {data.available === true
+                      ? "Approved ✅"
+                      : "Pending ⏳"}
+                  </span>
+
+                  <Link
+                    to={`/tools/${data.id}`}
+                    style={{
+                      width: "fit-content",
+                      padding: "6px 12px",
+                      backgroundColor: "#007bff",
+                      color: "white",
+                      borderRadius: 4,
+                      textDecoration: "none",
+                      marginTop:"10px "
+                    }}
+                  >
+                    View Tool
+                  </Link>
+                </div>
+              </div>
+            ))
+          : "No requests found."}
       </div>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## What changed?
- Added navigation from My Requests page to Tool Detail page
- Implemented fallback UI when tool is not found
- Added View Tool button linking to /tools/:id

## Why?
- To allow users to navigate from their request to the tool details
- To handle invalid or missing tool IDs 

## How to test
1. Go to My Requests page
2. Click "View Tool" button
3. Verify it navigates to correct Tool Detail page
4. Try an invalid tool ID in URL, confirm fallback message shows

## Screenshots (UI changes)
(Optional)
