### PR TITLE
Show empty state with Browse Tools link when no requests exist (#64)

### DIFF
--- a/frontend/src/components/ToolCard.jsx
+++ b/frontend/src/components/ToolCard.jsx
@@ -22,7 +22,7 @@ export default function ToolCard({ tool }) {
         {tool.category} • {tool.condition}
       </p>
 
-      <div style={{ marginTop: "auto" }}> {/* 👈 changed from 8 to "auto" */}
+      <div style={{ marginTop: "auto" }}>
         <Link to={`/tools/${tool.id}`}>View Details</Link>
       </div>
     </div>

--- a/frontend/src/pages/MyRequests.jsx
+++ b/frontend/src/pages/MyRequests.jsx
@@ -51,56 +51,82 @@ export default function MyRequests() {
           gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
         }}
       >
-        {requests.length >= 1
-          ? requests.map((data) => {
-              const requestStatus = (data.status || "unknown").toLowerCase();
+        {requests.length === 0 ? (
+          <div
+            style={{
+              textAlign: "center",
+              gridColumn: "1 / -1",
+              padding: "40px 0",
+            }}
+          >
+            <h3>You haven’t requested any tools yet.</h3>
 
-              return (
+            <Link
+              to="/tools"
+              style={{
+                display: "inline-block",
+                marginTop: "12px",
+                padding: "8px 16px",
+                backgroundColor: "#007bff",
+                color: "white",
+                borderRadius: 4,
+                textDecoration: "none",
+              }}
+            >
+              Browse tools
+            </Link>
+          </div>
+        ) : (
+          requests.map((data) => {
+            const requestStatus = (data.status || "unknown").toLowerCase();
+
+            return (
+              <div
+                key={data.id}
+                style={{
+                  border: "1px solid #ddd",
+                  borderRadius: 8,
+                  padding: 16,
+                  display: "flex",
+                  flexDirection: "column",
+                  justifyContent: "space-between",
+                }}
+              >
+                <h3 style={{ margin: 0 }}>
+                  {data.item?.name ?? "Unnamed Tool"}
+                </h3>
+
                 <div
-                  key={data.id}
                   style={{
-                    border: "1px solid #ddd",
-                    borderRadius: 8,
-                    padding: 16,
                     display: "flex",
                     flexDirection: "column",
-                    justifyContent: "space-between",
+                    gap: 8,
+                    marginTop: 12,
                   }}
                 >
-                  <h3 style={{ margin: 0 }}>{data.item?.name ?? "Unnamed Tool"}</h3>
+                  <span className="muted">Status:</span>
 
-                  <div
+                  <StatusBadge status={requestStatus} />
+
+                  <Link
+                    to={`/tools/${data.item?.id}`}
                     style={{
-                      display: "flex",
-                      flexDirection: "column",
-                      gap: 8,
-                      marginTop: 12,
+                      width: "fit-content",
+                      padding: "6px 12px",
+                      backgroundColor: "#007bff",
+                      color: "white",
+                      borderRadius: 4,
+                      textDecoration: "none",
+                      marginTop: "10px",
                     }}
                   >
-                    <span className="muted">Status:</span>
-
-                    {/* Badge should hug its content; fix that in StatusBadge styles */}
-                    <StatusBadge status={requestStatus} />
-
-                    <Link
-                      to={`/tools/${data.item?.id}`}
-                      style={{
-                        width: "fit-content",
-                        padding: "6px 12px",
-                        backgroundColor: "#007bff",
-                        color: "white",
-                        borderRadius: 4,
-                        textDecoration: "none",
-                        marginTop: "10px",
-                      }}
-                    >
-                      View Tool
-                    </Link>
-                  </div>
+                    View Tool
+                  </Link>
                 </div>
-              );
-            })
-          : "No requests found."}
+              </div>
+            );
+          })
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## What changed?
Instead of showing plain text, the UI now displays:
-  A message: "You haven’t requested any tools yet."
-  A "Browse tools" button linking to /tools

## Why?
- To improve user experience and prevent the page from feeling broken when the request list is empty.

## How to test
1. Navigate to the My Requests page.
2. Temporarily set requests to [] inside the try catch block in the MyRequests.jsx to simulate the empty state.
3. Verify that the empty state message is displayed.
4. Click the "Browse tools" button and confirm it navigates to /tools.
5. Confirm there are no console errors.

## Screenshots (UI changes)

<img width="1914" height="482" alt="Screenshot 2026-02-26 093030" src="https://github.com/user-attachments/assets/f5cbdf15-514f-4f91-a93a-63164c04d14e" />

