### PR TITLE
Feat/request to borrow post

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,9 +1,14 @@
+<<<<<<< Updated upstream
 import mockTools from "../mock/tools.mock.js";
 
 const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || "http://127.0.0.1:5000").replace(
   /\/$/,
   ""
 );
+=======
+const API_BASE_URL =
+  (import.meta.env.VITE_API_BASE_URL || "http://127.0.0.1:5000").replace(/\/$/, "");
+>>>>>>> Stashed changes
 
 class ApiError extends Error {
   constructor(message, { status, data, path }) {
@@ -15,7 +20,36 @@ class ApiError extends Error {
   }
 }
 
+<<<<<<< Updated upstream
 // Convert backend tool shape -> frontend-friendly tool shape
+=======
+function getAccessToken() {
+  return localStorage.getItem("access_token");
+}
+
+// Best-effort decode (no validation) to pull user id from JWT payload.
+// This is enough for local dev to call /api/borrows?user_id
+function getUserIdFromToken(token) {
+  try {
+    const [, payload] = token.split(".");
+    if (!payload) return null;
+
+    const json = atob(payload.replace(/-/g, "+").replace(/_/g, "/"));
+    const data = JSON.parse(json);
+
+    // common claim names:
+    return data.sub ?? data.user_id ?? data.id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Normalize backend tool shape -> frontend-friendly shape.
+ * Backend returns: is_available, available_quantity
+ * Frontend expects: available (boolean)
+ */
+>>>>>>> Stashed changes
 function normalizeTool(tool) {
   if (!tool || typeof tool !== "object") return tool;
 
@@ -32,10 +66,13 @@ function normalizeTool(tool) {
 }
 
 async function apiRequest(path, { headers, ...options } = {}) {
+  const token = getAccessToken();
+
   const res = await fetch(`${API_BASE_URL}${path}`, {
     ...options,
     headers: {
       "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
       ...headers,
     },
   });
@@ -55,7 +92,37 @@ async function apiRequest(path, { headers, ...options } = {}) {
   return data;
 }
 
+<<<<<<< Updated upstream
 // Tool catalog
+=======
+/**
+ * Auth
+ * POST /api/auth/login
+ * body: { email, password }
+ * returns: { access_token }
+ */
+export async function login({ email, password }) {
+  const data = await apiRequest("/api/auth/login", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+
+  const token = data?.access_token;
+  if (!token) {
+    throw new Error("Login succeeded but no access_token returned.");
+  }
+
+  localStorage.setItem("access_token", token);
+  return token;
+}
+
+// local-only logout (backend logout endpoint may be added later)
+export function logoutLocal() {
+  localStorage.removeItem("access_token");
+}
+
+// Tool catalog - getTools()
+>>>>>>> Stashed changes
 export async function getTools() {
   try {
     const data = await apiRequest("/api/tools");
@@ -72,8 +139,16 @@ export async function getTools() {
     console.warn("getTools: using mockTools fallback", err);
     return mockTools.map(normalizeTool);
   }
+<<<<<<< Updated upstream
 }
 
+=======
+
+  return tools.map(normalizeTool);
+}
+
+// getToolById()
+>>>>>>> Stashed changes
 export async function getToolById(id) {
   const idStr = String(id);
 
@@ -95,6 +170,7 @@ export async function getToolById(id) {
     if (!tool) throw new Error(`Tool ${idStr} not found`);
     return normalizeTool(tool);
   }
+<<<<<<< Updated upstream
 }
 
 // Borrowing
@@ -103,4 +179,43 @@ export async function createBorrowRequest(payload) {
     method: "POST",
     body: JSON.stringify(payload),
   });
+=======
+
+  return normalizeTool(tool);
+}
+
+/**
+ * Borrowing
+ * POST /api/borrows
+ * Headers: Authorization: Bearer <access_token>
+ * body: { item_id }
+ */
+export async function createBorrowRequest({ item_id }) {
+  return await apiRequest("/api/borrows/", {
+    method: "POST",
+    body: JSON.stringify({ item_id }),
+  });
+}
+
+/**
+ * Borrows list (legacy function name kept)
+ * If id is provided, hits /api/borrows?user_id=<id>
+ * If id is not provided, tries to infer from token.
+ */
+export async function getBorrows(id) {
+  const token = getAccessToken();
+  if (!token) return [];
+
+  let userId = id;
+  if (!userId) {
+    userId = getUserIdFromToken(token);
+  }
+
+  if (userId != null) {
+    return await apiRequest(`/api/borrows/?user_id=${userId}`);
+  }
+
+  // Fallback: may be admin-only later
+  return await apiRequest("/api/borrows/");
+>>>>>>> Stashed changes
 }

--- a/frontend/src/pages/ToolDetail.jsx
+++ b/frontend/src/pages/ToolDetail.jsx
@@ -13,6 +13,10 @@ export default function ToolDetail() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [requestError, setRequestError] = useState("");
 
+  // new: borrow request UX states
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [requestError, setRequestError] = useState("");
+
   useEffect(() => {
     let isMounted = true;
 
@@ -39,6 +43,7 @@ export default function ToolDetail() {
 
   const handleRequest = async () => {
     setRequestError("");
+<<<<<<< Updated upstream
     setIsSubmitting(true);
 
     try {
@@ -50,6 +55,19 @@ export default function ToolDetail() {
         borrower_id: borrowerId,
       });
 
+=======
+
+    const token = localStorage.getItem("access_token");
+    if (!token) {
+      setRequestError("Please log in to request a borrow.");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await createBorrowRequest({ item_id: Number(tool.id) });
+>>>>>>> Stashed changes
       setRequestSent(true);
     } catch (err) {
       setRequestError("Could not send request. Please try again.");
@@ -146,9 +164,13 @@ export default function ToolDetail() {
           )}
 
           {requestError && (
+<<<<<<< Updated upstream
             <p style={{ color: "#f87171", marginTop: 10 }}>
               {requestError}
             </p>
+=======
+            <p style={{ color: "#f87171", marginTop: 10 }}>{requestError}</p>
+>>>>>>> Stashed changes
           )}
         </div>
       </div>


### PR DESCRIPTION
## What changed?
Updated Tool Detail “Request to Borrow” to call POST /api/borrows/ with { item_id }
Added auth guard: shows “Please log in…” if no token is present
Added submitting + success UX: “Sending…” → “Request sent ✅” and disables button
Updated API helper to:
-attach Authorization: Bearer <access_token> automatically when present
-normalize tool availability (is_available/available_quantity → available)
-fix borrows endpoints to use trailing slash to avoid CORS preflight redirects

## Why?
Backend contract now requires JWT for mutation endpoints and derives borrower identity from the token. This completes ticket #66 and enables end-to-end borrow creation.

## How to test
1. Start backend + DB:
-cd backend
-uv run run.py
-confirm http://127.0.0.1:5000/health shows database connected

2. Start frontend:
-cd frontend
-npm install
-npm run dev

Log in to get a token (via existing login flow or curl):
-POST /api/auth/login returns access_token
-set it in browser devtools: localStorage.setItem("access_token", "<token>")

Navigate to a tool detail page and click Request to Borrow
-Expected: “Sending…” then “Request sent ✅”; button disables

Verify borrow is saved:
-GET /api/borrows/?user_id=<your_id> shows a new borrow with status "pending"
