### PR TITLE
Feature: Connect logout button to '/auth/logout' API call

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -11,9 +11,24 @@ export default function Navbar() {
   const location = useLocation();
   
   // Clear authentication data and redirect to login page
-  function handleLogout() {
-    localStorage.removeItem("token");
-    window.location.href = "/login";
+  async function handleLogout() {
+    try {
+      const response = await fetch("/api/auth/logout", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${localStorage.getItem("token")}`
+         },
+        });
+      
+      if (response.ok) {
+        localStorage.removeItem("token");
+        window.location.href = "/login";
+      }
+    } catch (err) {
+      console.warn(err);
+      throw(err);
+    }
   };
 
   return (


### PR DESCRIPTION
## What changed?
- This modifies `handleLogout()` function called by the Logout button. `handleLogout()` sends a `POST` request to '/auth/logout' API route before removing the JWT token from Local Storage, and returning to the Login page.

## Why?
- For security reasons, JWT token that's no longer in use needs to be "blacklisted" by the backend server.

## How to test
1. Log in using one of the seeded users emails (all sample users use the password `password123`),
2. Try to log out using the logout button.

## Acceptance Criteria
- [x] Frontend shows a logout button when logged in,
- [x] Clicking log out clears stored token locally,
- [x] If backend logout exists, `POST` `/api/auth/logout`, frontend calls it and then clears local token,
- [ ] After logout, protected actions require login again

Closes #96 