### PR TITLE
feat(frontend): add interactive admin actions and state management for borrows #69 

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -363,3 +363,27 @@ h3 {
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(59, 130, 246, 0.5);
 }
+
+/* ==================
+   Aprove & Return
+   =============== */
+
+.btn-success {
+  background-color: #127c39;
+  border: none;
+  color: #fff;
+}
+
+.btn-success:hover {
+  background-color: #0c5e2a;
+}
+
+.btn-secondary {
+  background-color: #303030;
+  border: none;
+  color: #fff;
+}
+
+.btn-secondary:hover {
+  background-color: #272727;
+}

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -231,3 +231,21 @@ export async function getAllBorrows() {
   // Try both /api/borrows and /api/borrows/ to avoid redirect preflight failures.
   return await apiRequestTryBothSlashes("/api/borrows", { auth: true });
 }
+
+/* =============================
+   Approve and return borrows
+============================= */
+
+export async function approveBorrow(id) {
+  return await apiRequestTryBothSlashes(`/api/borrows/${id}/approve`, {
+    method: "PATCH",
+    auth: true,
+  });
+}
+
+export async function returnBorrow(id) {
+  return await apiRequestTryBothSlashes(`/api/borrows/${id}/return`, {
+    method: "PATCH",
+    auth: true,
+  });
+}

--- a/frontend/src/pages/AdminBorrowList.jsx
+++ b/frontend/src/pages/AdminBorrowList.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { getAllBorrows } from "../lib/api";
+import { getAllBorrows, approveBorrow, returnBorrow } from "../lib/api";
 import StatusBadge from "../components/StatusBadge";
 
 export default function AdminBorrowList() {
@@ -114,6 +114,21 @@ export default function AdminBorrowList() {
 
             <div style={{ marginTop: "10px" }}>
               <StatusBadge status={borrow.status} />
+            </div>
+
+            <div style={{ marginTop: "10px"}}>
+              {borrow.status === "pending" &&
+                (<button
+                  className="btn btn-success">
+                  Approve Request
+                </button>)}
+              {borrow.status === "approved" &&
+                (<button
+                  className="btn btn-secondary">
+                  Mark as Returned
+                </button>)}
+              {borrow.status === "returned" &&
+              (<span className="note">Transaction Completed</span>)}
             </div>
           </div>
         ))}

--- a/frontend/src/pages/AdminBorrowList.jsx
+++ b/frontend/src/pages/AdminBorrowList.jsx
@@ -78,6 +78,32 @@ export default function AdminBorrowList() {
       </p>
     );
 
+  async function handleApprove(id) {
+    try {
+      const data = await approveBorrow(id);
+      setBorrows((prevBorrowList) =>
+        prevBorrowList.map((borrow) =>
+          borrow.id === id ? data : borrow
+        )
+      );
+    } catch (err) {
+      alert(err.message);
+    }
+  };
+
+  async function handleReturn(id) {
+    try {
+      const data = await returnBorrow(id);
+      setBorrows((prevBorrowList) =>
+        prevBorrowList.map((borrow) =>
+          borrow.id === id ? data : borrow
+        )
+      );
+    } catch (err) {
+      alert(err.message);
+    }
+  };
+
   return (
     <div
       style={{
@@ -116,19 +142,23 @@ export default function AdminBorrowList() {
               <StatusBadge status={borrow.status} />
             </div>
 
-            <div style={{ marginTop: "10px"}}>
+            <div style={{ marginTop: "10px" }}>
               {borrow.status === "pending" &&
                 (<button
-                  className="btn btn-success">
+                  className="btn btn-success"
+                  onClick={() => handleApprove(borrow.id)}
+                  >
                   Approve Request
                 </button>)}
               {borrow.status === "approved" &&
                 (<button
-                  className="btn btn-secondary">
+                  className="btn btn-secondary"
+                  onClick={() => handleReturn(borrow.id)}
+                  >
                   Mark as Returned
                 </button>)}
               {borrow.status === "returned" &&
-              (<span className="note">Transaction Completed</span>)}
+                (<span className="note">Transaction Completed</span>)}
             </div>
           </div>
         ))}


### PR DESCRIPTION
## What changed?
- Added `approveBorrow` and `returnBorrow` functions to `frontend/src/lib/api.js` to handle PATCH requests to the lifecycle endpoints.
- Implemented `handleApprove` and `handleReturn` logic in `AdminBorrowList.jsx` for "optimistic" UI updates.
- Added conditional rendering for action buttons based on borrow request status (`pending`, `approved`, or `returned`).
- Created custom CSS styles for `.btn-success` (green) and `.btn-secondary` (gray) in `index.css` for clear visual action hierarchy.
- Integrated error handling to display readable messages via `alert()` when API calls fail.

## Why?
- To complete the admin lifecycle for borrow requests, ensuring that tool availability is correctly updated in the backend.
- To provide administrators with a responsive and intuitive interface for managing the community library.
- This fulfills the final requirements for issue #69.

## How to test
1. Ensure both the backend (`uv run run.py`) and frontend (`npm run dev`) are running.
2. Log in as an administrator.

**Approval flow**:
1. Go to the Admin page from the navigation bar.
2. Click "Approve Request".
3. The badge changes to "Approved" instantly and the button changes to "Mark as Returned".

**Return Flow**:
1. Click "Mark as Returned" on an approved request.
2. The badge changes to "Returned" and buttons are replaced by a "Transaction Completed" note.

**Optional**:
If the backend is offline and you click on an action button, you should see a readable error alert.


## Screenshots (UI changes)
<img width="1158" height="878" alt="image" src="https://github.com/user-attachments/assets/dbf6de86-9d24-44bf-aec1-e35602c793ee" />
<img width="1171" height="867" alt="image" src="https://github.com/user-attachments/assets/eab13e1a-f227-40bf-bac4-36fe66397442" />
<img width="1173" height="870" alt="image" src="https://github.com/user-attachments/assets/1fb771d8-cae5-4d38-8f00-a943abd30879" />
<img width="1172" height="890" alt="image" src="https://github.com/user-attachments/assets/b3c45588-efe6-4536-b23d-d958df94c6ad" />

---
Closes Issue #69 