### PR TITLE
fix: add a trailing space to '/api/borrows' path

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -229,7 +229,7 @@ export async function getMyBorrows() {
 export async function getAllBorrows() {
   // GET can still preflight if Authorization header is present.
   // Try both /api/borrows and /api/borrows/ to avoid redirect preflight failures.
-  return await apiRequestTryBothSlashes("/api/borrows", { auth: true });
+  return await apiRequestTryBothSlashes("/api/borrows/", { auth: true });
 }
 
 /* =============================


### PR DESCRIPTION
Firefox had trouble accessing the admin borrows path.

## What changed?
- Added a trailing slash to the path in `getAllBorrows()` function.
